### PR TITLE
Use APR based string compare

### DIFF
--- a/libcrange/source/functions/yamlfile.c
+++ b/libcrange/source/functions/yamlfile.c
@@ -274,7 +274,7 @@ static range* _expand_cluster(range_request* rr,
     res = set_get_data(e->sections, section);
 
     if (!res) {
-        if(!strcmp(section, "CLUSTER")) {
+        if(!apr_strnatcmp(section, "CLUSTER")) {
             res = "";
         } else {
             char* cluster_section = apr_psprintf(req_pool,


### PR DESCRIPTION
In keeping with the spirit of using APR for more goodness, modify the recent strcmp change to use apr_strnatcmp.

Compiles and doesn't segfault when used to get CLUSTER and when CLUSTER does not exist.
