### PR TITLE
Update python_seco_range to be noarch

### DIFF
--- a/python_seco_range/index.yaml
+++ b/python_seco_range/index.yaml
@@ -1,3 +1,4 @@
 default:
   name: python-seco-range
+  arch: noarch
   version: '1.0'


### PR DESCRIPTION
It's pure python, shouldn't be architecture dependent.
