### PR TITLE
fixed ocaml range compilation problem on x86_64

### DIFF
--- a/librange/source/Makefile
+++ b/librange/source/Makefile
@@ -8,10 +8,13 @@ LIBS = unix
 
 PATH = /usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 
-LDPATH=-L /usr/lib/ocaml/site-lib/pcre/ -L /usr/local/lib -L /usr/lib 
+LDPATH=-L /usr/lib/ocaml/site-lib/pcre/ -L /usr/local/lib -L /usr/lib
+
+OCAML_PCRE=$(shell ocamlfind query pcre)
+OCAML_STDLIB=$(shell ocamlfind query unix)
 
 librange.so: camlcode.o librange.o 
-	ld -shared --whole-archive -o librange.so camlcode.o librange.o /usr/lib/ocaml/libunix.a /usr/lib/ocaml/libasmrun.a /usr/lib/ocaml/site-lib/pcre/libpcre_stubs.a -lm -lpcre -ldl
+	ld -fPIC -Bsymbolic -shared --whole-archive -o librange.so camlcode.o librange.o $(OCAML_STDLIB)/libunix.a $(OCAML_STDLIB)/libasmrun.a $(OCAML_PCRE)/libpcre_stubs.a -lm -lpcre -ldl
 
 
 # unused 
@@ -27,10 +30,10 @@ install:
 	install -m 755 librange.so $(DESTDIR)/usr/lib/
 
 camlcode.o: ncl
-	ocamlopt -I /usr/lib/ocaml/site-lib/pcre -output-obj -o camlcode.o unix.cmxa pcre.cmxa range_utils.cmx parser.cmx lexer.cmx memoize.cmx tinydns.cmx netmask.cmx admins.cmx netblocks.cmx hosts_netblocks.cmx evaluate.cmx range.cmx
+	ocamlopt -fPIC -I $(OCAML_PCRE) -output-obj -o camlcode.o unix.cmxa pcre/pcre.cmxa range_utils.cmx parser.cmx lexer.cmx memoize.cmx tinydns.cmx netmask.cmx admins.cmx netblocks.cmx hosts_netblocks.cmx evaluate.cmx range.cmx
 
 librange.o: librange.c
-	gcc -Wall -g -c librange.c -I /usr/lib/ocaml
+	gcc -fPIC -Wall -g -c librange.c -I $(OCAML_STDLIB)
 
 cleaner: clean
 	rm -f librange.so librange.o testrange camlcode.o pcre_stubs.o


### PR DESCRIPTION
From 3.12, ocaml starts to be compiled with -fPIC. This patch enables ocaml version range to be compiled on x86_64 system. Also, I added 'ocamlfind' to find some library paths so that no matter what ocaml users use, godi or original ocaml, they do not need to change the Makefile.
