### PR TITLE
libcrange builds on OSX

### DIFF
--- a/libcrange/scripts/build
+++ b/libcrange/scripts/build
@@ -3,14 +3,21 @@
 set -e
 set -x
 
-aclocal || exit 1
-libtoolize --force || exit 1
-autoheader || exit 1
-automake -a || exit 1
-autoconf || exit 1
-./configure --prefix=/usr || exit 1
-make || exit 1
-make install  || exit 1
+aclocal
+case "${OSTYPE}" in
+	darwin*)
+		glibtoolize --force
+		;;
+	*)
+		libtoolize --force
+		;;
+esac
+autoheader
+automake -a
+autoconf
+./configure --prefix=/usr
+make
+make install
 cd perl
-sh ./build || exit 1
+sh ./build
 

--- a/libcrange/source/configure.ac
+++ b/libcrange/source/configure.ac
@@ -90,7 +90,6 @@ AC_CHECK_PERL
 AC_CHECK_PCRE
 AC_CHECK_APR
 
-AC_CHECK_LIB([crypt], [crypt_r], [], [exit 1])
 AC_CHECK_LIB([m], [sin], [], [exit 1])
 AC_CHECK_LIB([pthread], [pthread_create], [], [exit 1])
 AC_CHECK_LIB([z], [zlibVersion], [], [exit 1])


### PR DESCRIPTION
- in build, -e is set, so the || exit 1 statements are useless
- check OSTYPE and use glibtoolize if on OSX
- libcrypt and crypt_r aren't useful in the context of libcrange and makes the build fail on OSX, so it has been purged from configure.ac
